### PR TITLE
Set de datos donde el test unitario devuelve fail

### DIFF
--- a/spec/EncontrarBordesSpec.js
+++ b/spec/EncontrarBordesSpec.js
@@ -4,4 +4,9 @@ describe('EncontrarBordes', function() {
 
 		expect(encontrar_bordes(relieve)).toEqual([[1, 0, 1, 1, 0, 0], [0, 0, 0, 1, 0, 0], [0, 0, 1, 1, 0, 1], [0, 0, 1, 0, 0, 1], [0, 1, 0, 0, 1, 0 ]]);
 	});
+	
+	it('Set de datos donde falla, hay que mirar los valores arriba y abajo', function(){
+		var relieve = [[8, 9, 2, 2, 3, 5], [9, 8, 3, 2, 4, 5], [9, 7, 2, 1, 4, 3], [9, 9, 2, 4, 4, 3], [9, 2, 3, 4, 3, 5]];
+		expect(encontrar_bordes(relieve)).toEqual([[ 1, 0, 1, 1, 0, 0 ], [ 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 1, 0, 1 ], [ 0, 0, 0, 0, 0, 1 ], [ 0, 1, 0, 0, 1, 0 ]]);
+	})
 });


### PR DESCRIPTION
El algoritmo solo mira los vecinos en la misma fila y tiene que mirar a los de arriba y abajo.

Ejemplo:
   v
v x v
   v

Antes te hacia ver todos los vecinos:

v v v
v x v
v v v

Descubierto por @juanrapoport
